### PR TITLE
Add semaphore example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # gopumpkin
 Small examples on different Golang topics
 
@@ -7,8 +8,10 @@ Small examples on different Golang topics
 - context
 - functions
 - struct & interface
-- goroutine & channel
+- concurrency
     - worker
+    - semaphore
+    - sync
 - file I/O & logging
 - serialize and deserialize
 - reflection

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Small examples on different Golang topics
 - functions
 - struct & interface
 - concurrency
+    - goroutine & channel
     - worker
     - semaphore
     - sync

--- a/src/lessons/semaphore.go
+++ b/src/lessons/semaphore.go
@@ -1,0 +1,34 @@
+/* semaphore differentiates from mutex at
+it set how many goroutines can access the
+code at the same time while mutex limit that
+there can be only one goroutine which can
+access the code at one time
+*/
+
+package main
+
+import (
+	"flag"
+)
+
+func process(jobs int, size int) {
+	init := 0
+	sem := make(chan int, size)
+
+	for init < jobs {
+		sem <- 1
+		go func(init int) {
+			// fmt.Printf("processing job %d\n", init)
+			// time.Sleep(100 * time.Millisecond)
+			<-sem
+		}(init)
+		init++
+	}
+}
+
+func main() {
+	jobs := flag.Int("j", 100, "number of jobs submitted")
+	sn := flag.Int("s", 10, "maximum concurrent access")
+	flag.Parse()
+	process(*jobs, *sn)
+}

--- a/src/lessons/semaphore_test.go
+++ b/src/lessons/semaphore_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func BenchmarkSemaphore(b *testing.B) {
+	for _, i := range []int{1, 10, 100} {
+		b.StopTimer()
+		b.StartTimer()
+		for j := 0; j < b.N; j++ {
+			process(j, i)
+		}
+		b.StopTimer()
+		b.ReportAllocs()
+	}
+}

--- a/src/lessons/semaphore_test.go
+++ b/src/lessons/semaphore_test.go
@@ -1,15 +1,24 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func BenchmarkSemaphore(b *testing.B) {
-	for _, i := range []int{1, 10, 100} {
-		b.StopTimer()
-		b.StartTimer()
-		for j := 0; j < b.N; j++ {
-			process(j, i)
-		}
-		b.StopTimer()
-		b.ReportAllocs()
+	// test if the size of the buffered channel will speed things up and it actually helps to
+	// an extend per the following table
+	/*
+		BenchmarkSemaphore/buffered_channel_size:_10-4         	   10000	   2849151 ns/op
+		BenchmarkSemaphore/buffered_channel_size:_100-4        	    5000	   1574254 ns/op
+		BenchmarkSemaphore/buffered_channel_size:_1000-4       	   10000	   2414398 ns/op
+		BenchmarkSemaphore/buffered_channel_size:_10000-4      	   10000	   2715718 ns/op
+	*/
+	for _, i := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("buffered channel size: %d", i), func(b *testing.B) {
+			for j := 0; j < b.N; j++ {
+				process(j, i)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Semaphores are used for restraining concurrency in Golang. In this example, a buffered channel is used to serve the semaphore functionality. 